### PR TITLE
Focus License text to only key files #2

### DIFF
--- a/ClearlyLicensedMetrics.md
+++ b/ClearlyLicensedMetrics.md
@@ -233,8 +233,8 @@ License Texts
 -------------
 
 This scoring element is awarded if there is copy of the full license text
-available in the project for every referenced license found in the core facet.
-This is a binary score element.
+available in one of the key files for every referenced license found in the
+core facet. This is a binary score element.
 
 
 ClearlyLicensed Scoring Formula


### PR DESCRIPTION
This changes the defeinition for the License Texts elements to take into account only these that
are found in "key files". Key files are either top level common files (e.g. LICENSE, COPYING or a README or package manifest ) or in some cases non-top level files that are found at a conventional well known location for a certain package type (e.g. Debian or Gem control files, pypi wheel metadata, etc.)
Signed-off-by: Philippe Ombredanne <pombredanne@nexb.com>