### PR TITLE
Top PyPI Packages: Use 30-days data, 365 is no longer available

### DIFF
--- a/top-packages/fetch-top-package-download-urls.py
+++ b/top-packages/fetch-top-package-download-urls.py
@@ -105,7 +105,7 @@ def pypi_source_url(name, version):
 
 def process_pypi():
     print('Querying PyPI for latest package version and source URLs...')
-    for pypi_package in get_pypi_packages('./source-data/top-pypi-packages-365-days.json'):
+    for pypi_package in get_pypi_packages('./source-data/top-pypi-packages-30-days.min.json'):
         name = pypi_package.get('project')
         latest_version = pypi_latest_release(name)
 


### PR DESCRIPTION
I needed to remove the 365-day data from https://hugovk.github.io/top-pypi-packages/ because it was using more quota than available, so let's use the 30-day one instead.

Let's also use the slightly smaller minified version.

Re: https://github.com/hugovk/top-pypi-packages/pull/21, https://github.com/hugovk/top-pypi-packages/pull/20, https://github.com/hugovk/top-pypi-packages/issues/19.
